### PR TITLE
BAD_POOL_CALLER driver crash fix 

### DIFF
--- a/sys/create.c
+++ b/sys/create.c
@@ -148,10 +148,10 @@ DokanGetFCB(
         ExFreePool(FileName);
     }
 
+    InterlockedIncrement(&fcb->FileCount);
     ExReleaseResourceLite(&Vcb->Resource);
     KeLeaveCriticalRegion();
 
-    InterlockedIncrement(&fcb->FileCount);
     return fcb;
 }
 
@@ -172,7 +172,7 @@ DokanFreeFCB(
     ExAcquireResourceExclusiveLite(&vcb->Resource, TRUE);
     ExAcquireResourceExclusiveLite(&Fcb->Resource, TRUE);
 
-    Fcb->FileCount--;
+    InterlockedDecrement(&Fcb->FileCount);
 
     if (Fcb->FileCount == 0) {
 


### PR DESCRIPTION
When copying lots of small files (reproducible with mirrorfs) dokanx.sys my crash with BAD_POOL_CALLER error. The fix was proposed for original dokan at https://code.google.com/p/dokan/issues/detail?id=229 seems to work and should be merged to dokanx.
