### PR TITLE
Fixed GetRawDeviceName result processing.

### DIFF
--- a/dokanx/access.cpp
+++ b/dokanx/access.cpp
@@ -68,7 +68,7 @@ DokanOpenRequestorToken(PDOKAN_FILE_INFO FileInfo)
 	eventInfo->SerialNumber = eventContext->SerialNumber;
 
     WCHAR rawDeviceName[MAX_PATH];
-    if (GetRawDeviceName(instance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
+    if (!GetRawDeviceName(instance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
     {
         logw(L"Failed to get raw device name from <%s>", instance->DeviceName);
         return INVALID_HANDLE_VALUE;

--- a/dokanx/dokan.cpp
+++ b/dokanx/dokan.cpp
@@ -579,8 +579,9 @@ BOOL SendReleaseIRP(LPCWSTR	DeviceName)
     logw(L"send release");
 
     WCHAR rawDeviceName[MAX_PATH];
-    if (GetRawDeviceName(DeviceName, rawDeviceName, _countof(rawDeviceName)))
+    if (!GetRawDeviceName(DeviceName, rawDeviceName, _countof(rawDeviceName)))
     {
+        logw(L"Failed to get raw device name from <%s>", DeviceName);
         return FALSE;
     }
 

--- a/dokanx/timeout.cpp
+++ b/dokanx/timeout.cpp
@@ -55,8 +55,9 @@ DokanResetTimeout(ULONG Timeout, PDOKAN_FILE_INFO FileInfo)
 	eventInfo->ResetTimeout.Timeout = Timeout;
         
     WCHAR rawDeviceName[MAX_PATH];
-    if (GetRawDeviceName(instance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
+    if (!GetRawDeviceName(instance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
     {
+        logw(L"Failed to get raw device name from <%s>", instance->DeviceName);
         return FALSE;
     }
 
@@ -84,7 +85,7 @@ DokanKeepAlive(
 	BOOL	status;
 
     WCHAR rawDeviceName[MAX_PATH];
-    if (GetRawDeviceName(DokanInstance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
+    if (!GetRawDeviceName(DokanInstance->DeviceName, rawDeviceName, _countof(rawDeviceName)))
     {
         logw(L"Failed to get raw device name from <%s>", DokanInstance->DeviceName);
         return ERROR_INVALID_PARAMETER;


### PR DESCRIPTION
Corrected someones inaccuracy that leaded to mirrorfs (or other FS-app) to mount disk, worked for some time and quietly detached disk.
